### PR TITLE
fix dropped decryption error

### DIFF
--- a/oss/encryption_client.go
+++ b/oss/encryption_client.go
@@ -208,6 +208,9 @@ func (e *EncryptionClient) getObjectSecurely(ctx context.Context, request *GetOb
 		}
 
 		result.Body, err = cc.DecryptContent(result.Body)
+		if err != nil {
+			return nil, fmt.Errorf("DecryptContent: %w", err)
+		}
 	}
 
 	if discardCount > 0 && err == nil {


### PR DESCRIPTION
This fixes a dropped `err` variable in the `oss` package related to decryption of an object.